### PR TITLE
Fix latest milestone query in Actions workflow

### DIFF
--- a/.github/workflows/auto-milestone.yml
+++ b/.github/workflows/auto-milestone.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
   manage-milestone:

--- a/.github/workflows/auto-milestone.yml
+++ b/.github/workflows/auto-milestone.yml
@@ -44,10 +44,10 @@ jobs:
             exit 0
           fi
 
-          latest_milestone=$(gh api --paginate --slurp \
+          latest_milestone=$(gh api --paginate \
             -H "X-GitHub-Api-Version: 2026-03-10" \
             "repos/${GITHUB_REPOSITORY}/milestones?state=open&per_page=100" \
-            --jq '[.[][]] | max_by(.number) | .number // empty')
+            --jq '.[].number' | sort -n | tail -n 1)
 
           if [[ -z "${latest_milestone}" ]]; then
             echo "No open milestones are available."


### PR DESCRIPTION
## Summary

- remove the unsupported combination of `gh api --slurp` and `--jq`
- emit milestone numbers per page and select the highest number with `sort`/`tail`
- grant `pull-requests: write` so the workflow can update PR milestones

Fixes the failures observed in Actions runs 32142603200 and 32188046707.